### PR TITLE
Fix install editable with pyproject toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 .idea/
 *.python-version
 .coverage
+_version.py
 
 djutils/
 manage.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 name = "django-single-session"
 version = "0.1.1"
 authors = [{name = "Willem Van Onsem", email = "hapythexeu+gh@gmail.com"}]
+# The following seems to be defined outside of pyproject.toml
+dynamic = ['description', 'readme', 'requires-python', 'license']
 
 [build-system]
 requires = ['setuptools>=45', 'wheel', 'setuptools_scm[toml]>=6.2']


### PR DESCRIPTION
I had some problems with the editable installation with pip and I corrected them as instructed in the error messages.
`python -m pip install -e {PATH DIR}/django-single-session`